### PR TITLE
Explicit array support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ serde = "1.0"
 
 [dev-dependencies]
 serde_derive = "1.0"
+serde_json = "1.0"
+
+[features]
+arrays = []

--- a/src/de.rs
+++ b/src/de.rs
@@ -42,7 +42,6 @@ impl<'lua, 'de> serde::Deserializer<'de> for Deserializer<'lua> {
             Value::Table(v) => {
                 let len = v.len()? as usize;
                 if !table_is_array(&v)? {
-                    println!("Desering map");
                     let mut deserializer = MapDeserializer(v.pairs(), None);
                     let map = visitor.visit_map(&mut deserializer)?;
                     let remaining = deserializer.0.count();
@@ -52,7 +51,6 @@ impl<'lua, 'de> serde::Deserializer<'de> for Deserializer<'lua> {
                         Err(serde::de::Error::invalid_length(len, &"fewer elements in array"))
                     }
                 } else {
-                    println!("Desering array");
                     let mut deserializer = SeqDeserializer(v.sequence_values());
                     let seq = visitor.visit_seq(&mut deserializer)?;
                     let remaining = deserializer.0.count();

--- a/src/de.rs
+++ b/src/de.rs
@@ -6,6 +6,7 @@ use rlua::{Value, TablePairs, TableSequence};
 use error::{Error, Result};
 
 #[cfg(feature = "arrays")]
+#[inline]
 fn table_is_array(t: &rlua::Table) -> Result<bool> {
     let mt_arr: Option<bool> = if let Some(mt) = t.get_metatable() {
         mt.get("__array")?

--- a/src/de.rs
+++ b/src/de.rs
@@ -428,7 +428,27 @@ mod tests {
             "#).eval().unwrap();
             let json: serde_json::Value = from_value(value).unwrap();
             let got = serde_json::to_string(&json).unwrap();
+            assert_eq!(expected, got);
+            
+            let expected = String::from("[]");
+            let value = lua.load(
+            r#"
+            a = {}
+            setmetatable(a, {__array = true})
+            return a
+            "#).eval().unwrap();
+            let json: serde_json::Value = from_value(value).unwrap();
+            let got = serde_json::to_string(&json).unwrap();  
+            assert_eq!(expected, got);
 
+            let expected = String::from("{}");
+            let value = lua.load(
+                r#"
+                a = {}
+                return a
+                "#).eval().unwrap();
+            let json: serde_json::Value = from_value(value).unwrap();
+            let got = serde_json::to_string(&json).unwrap();
             assert_eq!(expected, got);
         });
     }


### PR DESCRIPTION
This PR adds a feature that implements a way to mark a table as an array explicitly using the (unofficial) `__array` field in its metatable.

This means that serializers that use `deserialize_any` can also get arrays when the feature is enabled and the metatable field is set.